### PR TITLE
fix: Add Chromium to Railway deployment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-aptPkgs = ["tesseract-ocr", "tesseract-ocr-eng"]
+aptPkgs = ["tesseract-ocr", "tesseract-ocr-eng", "chromium", "chromium-driver"]
 
 [phases.install]
 cmds = ["pip install -r requirements.txt"]


### PR DESCRIPTION
Add chromium and chromium-driver to nixpacks.toml
This will install Chrome on Railway so Selenium can work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Documentation
  - None

- Refactor
  - None

- Style
  - None

- Tests
  - None

- Chores
  - Expanded system dependencies to include Chromium and its driver alongside existing OCR packages, improving environment readiness and reliability for features that require a browser engine.

- Revert
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->