### PR TITLE
fix: Use correct Chromium package names for Ubuntu

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-aptPkgs = ["tesseract-ocr", "tesseract-ocr-eng", "chromium", "chromium-driver"]
+aptPkgs = ["tesseract-ocr", "tesseract-ocr-eng", "chromium-browser", "chromium-chromedriver"]
 
 [phases.install]
 cmds = ["pip install -r requirements.txt"]


### PR DESCRIPTION
Change from 'chromium' to 'chromium-browser'
Change from 'chromium-driver' to 'chromium-chromedriver' These are the correct package names for Ubuntu/Debian.